### PR TITLE
Added toObject() to TermMap and PrefixMap

### DIFF
--- a/lib/environment.js
+++ b/lib/environment.js
@@ -51,6 +51,19 @@ function mixin (rdf) {
     return iri
   }
 
+  rdf.PrefixMap.prototype.toObject = function () {
+    var obj = {};
+
+    for (var prefix in this) {
+      if (typeof this[prefix] === 'function') {
+        continue;
+      }
+      obj[prefix] = this[prefix];
+    }
+
+    return obj;
+  }
+
   rdf.TermMap = function (i) {
     return Object.defineProperties({}, {
       resolve: {
@@ -85,6 +98,19 @@ function mixin (rdf) {
           }
 
           return this
+        }
+      },
+      toObject: {
+        writable: false, configurable: false, enumerable: true, value: function () {
+          var obj = {};
+
+          for (var t in this) {
+            if (typeof this[t] === 'function') {
+              continue;
+            }
+            obj[t] = this[t];
+          }
+          return obj;
         }
       }
     }).addAll(i)


### PR DESCRIPTION
In order to provide a quick access to the prefixes defined in the Profile to be mainly use in the serializers. This way we avoid having functions that are not part of the set of prefixes or terms.

The use with JSON-LD context has been tested and it works out of the box.

```
var profile = rdf.createProfile();
var context = profile.prefixes.toObject();
```

Hope you think is interesting. Up to you to accept and merge it ;)
