### PR TITLE
CURIE code improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+coverage
 node_modules
 test/support/browser-test.js
 test/support/mocha.css

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -11,19 +11,22 @@ function mixin (rdf) {
 
   rdf.PrefixMap.prototype.resolve = function (curie) {
     if (curie.indexOf('://') !== -1) {
-      throw new Error('string looks like an IRI')
+      // string looks like an IRI
+      return
     }
 
     var separator = curie.indexOf(':')
 
     if (separator === -1) {
-      throw new Error('separator not found')
+      // separator not found
+      return
     }
 
     var prefix = curie.substr(0, separator).toLowerCase()
 
     if (!(prefix in this)) {
-      throw new Error('prefix is not defined')
+      // prefix is not defined
+      return
     }
 
     return this[prefix].concat(curie.substr(separator + 1))

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -37,10 +37,8 @@ function mixin (rdf) {
   }
 
   rdf.PrefixMap.prototype.shrink = function (iri) {
-    var reserved = ['addAll', 'resolve', 'setDefault', 'shrink']
-
     for (var prefix in this) {
-      if (reserved.indexOf(prefix) !== -1) {
+      if (typeof this[prefix] !== 'string') {
         continue
       }
 

--- a/test/environment.js
+++ b/test/environment.js
@@ -61,6 +61,30 @@ module.exports = function () {
         assert.equal(expanded, 'http://example.org/test')
       })
 
+      it('.resolve should ignore IRIs', function () {
+        var prefixMap = new rdf.PrefixMap({ex: 'http://example.org/'})
+
+        var expanded = prefixMap.resolve('http://example.org')
+
+        assert.equal(expanded, undefined)
+      })
+
+      it('.resolve should ignore strings without separator', function () {
+        var prefixMap = new rdf.PrefixMap({ex: 'http://example.org/'})
+
+        var expanded = prefixMap.resolve('test')
+
+        assert.equal(expanded, undefined)
+      })
+
+      it('.resolve should ignore strings with unknown prefix', function () {
+        var prefixMap = new rdf.PrefixMap({ex: 'http://example.org/'})
+
+        var expanded = prefixMap.resolve('ex1:test')
+
+        assert.equal(expanded, undefined)
+      })
+
       it('.setDefault should set the default namespace', function () {
         var prefixMap = new rdf.PrefixMap()
 

--- a/test/environment.js
+++ b/test/environment.js
@@ -107,6 +107,14 @@ module.exports = function () {
         assert.equal(shrinked, 'ex:test')
         assert.equal(shrinkedDefault, ':test')
       })
+
+      it('.shrink should return the IRI if no prefix was found', function () {
+        var prefixMap = new rdf.PrefixMap({ex: 'http://example.org/1/'})
+
+        var shrinked = prefixMap.shrink('http://example1.org/1/test')
+
+        assert.equal(shrinked, 'http://example1.org/1/test')
+      })
     })
 
     describe('Profile', function () {


### PR DESCRIPTION
- return undefined in .resolve() on error
- filter valid prefixes in .shrink() based on typeof === 'string'