### PR TITLE
Replace rdf-dataset-simple with rdf-dataset-indexed

### DIFF
--- a/lib/Dataset.js
+++ b/lib/Dataset.js
@@ -1,6 +1,6 @@
 const normalize = require('rdf-normalize')
 const quadToNTriples = require('@rdfjs/to-ntriples').quadToNTriples
-const Dataset = require('rdf-dataset-simple')
+const Dataset = require('rdf-dataset-indexed/dataset')
 const Quad = require('./Quad')
 
 class DatasetExt extends Dataset {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@rdfjs/data-model": "^1.1.0",
     "@rdfjs/to-ntriples": "^1.0.1",
-    "rdf-dataset-simple": "^1.0.0",
+    "rdf-dataset-indexed": "^0.1.0",
     "rdf-normalize": "^1.0.0"
   },
   "devDependencies": {

--- a/test/DataFactory.js
+++ b/test/DataFactory.js
@@ -399,12 +399,21 @@ describe('DataFactory', () => {
       assert.strictEqual(typeof rdf.dataset, 'function')
     })
 
-    it('should implement the extended Dataset interface', () => {
-      let dataset = rdf.dataset()
+    describe('implements the extended Dataset interface', () => {
+      it('should implement .equals', () => {
+        const dataset = rdf.dataset()
+        assert.strictEqual(typeof dataset.equals, 'function')
+      })
 
-      assert.strictEqual(typeof dataset.equals, 'function')
-      assert.strictEqual(typeof dataset.toCanonical, 'function')
-      assert.strictEqual(typeof dataset.toString, 'function')
+      it('should implement .toCanonical', () => {
+        const dataset = rdf.dataset()
+        assert.strictEqual(typeof dataset.toCanonical, 'function')
+      })
+
+      it('should implement .toString', () => {
+        const dataset = rdf.dataset()
+        assert.strictEqual(typeof dataset.toString, 'function')
+      })
     })
 
     it('should initialize the Dataset with the given quads', () => {


### PR DESCRIPTION
I also reworked a test to split it into 3 separate tests.

Before this PR this test would fail with unhelpful messages such as:

```
should implement the extended Dataset interface:

      AssertionError [ERR_ASSERTION]: Input A expected to strictly equal input B:
+ expected - actual
- 'undefined'
+ 'function'
```

After this PR, tests output will show which of the extended dataset interface methods are missing.