### PR TITLE
rdf.dataset should always return instances of DatasetExt

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@rdfjs/data-model": "^1.1.0",
     "@rdfjs/to-ntriples": "^1.0.1",
-    "rdf-dataset-indexed": "^0.1.0",
+    "rdf-dataset-indexed": "^0.2.0",
     "rdf-normalize": "^1.0.0"
   },
   "devDependencies": {

--- a/test/DataFactory.js
+++ b/test/DataFactory.js
@@ -2,6 +2,7 @@
 
 const assert = require('assert')
 const rdf = require('../lib/DataFactory')
+const DatasetExt = require('../lib/Dataset')
 const standard = require('@rdfjs/data-model/test')
 
 describe('DataFactory', () => {
@@ -397,6 +398,16 @@ describe('DataFactory', () => {
   describe('.dataset', () => {
     it('should be a function', () => {
       assert.strictEqual(typeof rdf.dataset, 'function')
+    })
+
+    it('should return a DatasetExt instance', () => {
+      assert.strictEqual(rdf.dataset() instanceof DatasetExt, true)
+    })
+
+    it('should always return a DatasetExt instance', () => {
+      assert.strictEqual(rdf.dataset().clone() instanceof DatasetExt, true)
+      assert.strictEqual(rdf.dataset().merge(rdf.dataset()) instanceof DatasetExt, true)
+      assert.strictEqual(rdf.dataset().filter(() => true) instanceof DatasetExt, true)
     })
 
     describe('implements the extended Dataset interface', () => {


### PR DESCRIPTION
Failing test for this issue