### PR TITLE
build(deps): update clownface to v2

### DIFF
--- a/ClownfaceFactory.js
+++ b/ClownfaceFactory.js
@@ -1,15 +1,3 @@
-import clownface from 'clownface'
-
-class ClownfaceFactory {
-  clownface ({ ...args } = {}) {
-    if (!args.dataset && typeof this.dataset === 'function') {
-      args.dataset = this.dataset()
-    }
-
-    return clownface({ ...args, factory: this })
-  }
-}
-
-ClownfaceFactory.exports = ['clownface']
+import ClownfaceFactory from 'clownface/Factory.js'
 
 export default ClownfaceFactory

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@rdfjs/term-set": "^2.0.1",
     "@rdfjs/to-ntriples": "^2.0.0",
     "@rdfjs/traverser": "^0.1.1",
-    "clownface": "^1.5.1",
+    "clownface": "^2.0.0",
     "readable-stream": "^4.3.0"
   },
   "devDependencies": {

--- a/test/ClownfaceFactory.test.js
+++ b/test/ClownfaceFactory.test.js
@@ -1,10 +1,11 @@
 import { strictEqual } from 'assert'
+import NamespaceFactory from '@rdfjs/namespace/Factory.js'
 import { describe, it } from 'mocha'
 import ClownfaceFactory from '../ClownfaceFactory.js'
 import { DataFactory, DatasetFactory, Environment } from '../index.js'
 import NamedNode from '../lib/NamedNode.js'
 
-const env = new Environment([ClownfaceFactory, DataFactory, DatasetFactory])
+const env = new Environment([ClownfaceFactory, DataFactory, DatasetFactory, NamespaceFactory])
 
 describe('ClownfaceFactory', () => {
   it('should be a constructor', () => {
@@ -32,7 +33,7 @@ describe('ClownfaceFactory', () => {
     })
 
     it('should not try to create a dataset if the environment doesn\'t implement DatasetFactory', () => {
-      const env = new Environment([ClownfaceFactory, DataFactory])
+      const env = new Environment([ClownfaceFactory, DataFactory, NamespaceFactory])
       const ptr = env.clownface()
 
       strictEqual(typeof ptr.dataset, 'undefined')


### PR DESCRIPTION
This updates clownface to version 2 which is now ESM and no longer depends on v1 versions of other RDF/JS packages